### PR TITLE
Add number keyboard type to balance and barcode fields

### DIFF
--- a/lib/presentation/editor/editor.screen.dart
+++ b/lib/presentation/editor/editor.screen.dart
@@ -127,11 +127,13 @@ class _EditorScreenState extends ConsumerState<EditorScreen> {
                   LabeledTextField(
                     labelText: '잔액',
                     controller: widget.balanceController,
+                    keyboardType: TextInputType.number,
                   ),
                 const Divider(),
                 LabeledTextField(
                   labelText: '바코드',
                   controller: widget.barcodeController,
+                  keyboardType: TextInputType.number,
                 ),
               ],
             ),


### PR DESCRIPTION
This pull request adds the number keyboard type to the balance and barcode fields in the EditorScreen class. This will improve the user experience by making it easier to input numerical values.

No issues were fixed in this pull request.