### PR TITLE
Add maxLines property to AutoSizeText in PlaceholderIcon widget

### DIFF
--- a/lib/presentation/common/placeholder_icon.widget.dart
+++ b/lib/presentation/common/placeholder_icon.widget.dart
@@ -26,6 +26,7 @@ class PlaceholderIcon extends StatelessWidget {
             ),
             AutoSizeText(
               message,
+              maxLines: 1,
               style: Theme.of(context).textTheme.headlineSmall,
             ),
           ],


### PR DESCRIPTION
This pull request adds a `maxLines` property to the `AutoSizeText` widget in the `PlaceholderIcon` class. This property limits the number of lines that the text can occupy, preventing it from overflowing and improving the overall layout of the widget.