### PR TITLE
Update voucher repository and API to use presigned URLs for images

### DIFF
--- a/lib/data/repositories/voucher.repository.dart
+++ b/lib/data/repositories/voucher.repository.dart
@@ -113,7 +113,7 @@ class VoucherRepositoryImpl implements VoucherRepository {
   }
 
   @override
-  Future<String> getImageUrl(int id) async {
-    return await _voucherApi.getImageUrl(id);
+  Future<String> getImagePresignedUrl(int id) async {
+    return await _voucherApi.getImagePresignedUrl(id);
   }
 }

--- a/lib/data/sources/voucher.api.dart
+++ b/lib/data/sources/voucher.api.dart
@@ -1,5 +1,9 @@
+// 🎯 Dart imports:
+import 'dart:io';
+
 // 📦 Package imports:
 import 'package:dio/dio.dart';
+import 'package:mime/mime.dart';
 
 // 🌎 Project imports:
 import 'package:gifthub/data/dto/giftcard.dto.dart';
@@ -116,14 +120,16 @@ class VoucherApi {
     final String imagePath,
     final String uploadTarget,
   ) async {
-    String fileName = imagePath.split('/').last;
+    final file = File.fromUri(Uri.parse(imagePath));
     await Dio().put(
       uploadTarget,
-      data: FormData.fromMap(
-        {
-          'file': await MultipartFile.fromFile(imagePath, filename: fileName),
+      options: Options(
+        headers: {
+          Headers.contentTypeHeader: lookupMimeType(file.path),
+          Headers.contentLengthHeader: file.lengthSync(),
         },
       ),
+      data: file.openRead(),
     );
   }
 

--- a/lib/data/sources/voucher.api.dart
+++ b/lib/data/sources/voucher.api.dart
@@ -127,9 +127,9 @@ class VoucherApi {
     );
   }
 
-  Future<String> getImageUrl(final int id) async {
+  Future<String> getImagePresignedUrl(final int id) async {
     final response = await dio.get('/vouchers/$id/image');
     // ignore: avoid_dynamic_calls
-    return response.data['image_url'];
+    return response.data['presigned_url'];
   }
 }

--- a/lib/domain/commands/fetch_voucher_image_url.command.dart
+++ b/lib/domain/commands/fetch_voucher_image_url.command.dart
@@ -18,7 +18,7 @@ class FetchVoucherImageUrlCommand extends Command {
 
   Future<String> call() async {
     try {
-      final url = await _voucherRepository.getImageUrl(id);
+      final url = await _voucherRepository.getImagePresignedUrl(id);
       logSuccess({
         'id': id.toString(),
         'url': url,

--- a/lib/domain/repositories/voucher.repository.dart
+++ b/lib/domain/repositories/voucher.repository.dart
@@ -45,5 +45,5 @@ abstract class VoucherRepository {
 
   Future<void> uploadImage(String imagePath, String uploadTarget);
 
-  Future<String> getImageUrl(int id);
+  Future<String> getImagePresignedUrl(int id);
 }

--- a/lib/presentation/providers/command.provider.dart
+++ b/lib/presentation/providers/command.provider.dart
@@ -16,6 +16,7 @@ import 'package:gifthub/domain/commands/fetch_new_notification_count.command.dar
 import 'package:gifthub/domain/commands/fetch_notification.command.dart';
 import 'package:gifthub/domain/commands/fetch_notifications.command.dart';
 import 'package:gifthub/domain/commands/fetch_pending_voucher_count.command.dart';
+import 'package:gifthub/domain/commands/fetch_voucher_image_url.command.dart';
 import 'package:gifthub/domain/commands/invoke_oauth.command.dart';
 import 'package:gifthub/domain/commands/retrieve_voucher.command.dart';
 import 'package:gifthub/domain/commands/revoke_oauth.command.dart';
@@ -259,6 +260,15 @@ final acquireGiftcardCommandProvider =
   return AcquireGiftcardComand(
     id,
     giftcardRepository: ref.watch(giftcardRepositoryProvider),
+    analytics: ref.watch(firebaseAnalyticsProvider),
+  );
+});
+
+final fetchVoucherImageUrlCommandProvider =
+    Provider.family.autoDispose<FetchVoucherImageUrlCommand, int>((ref, id) {
+  return FetchVoucherImageUrlCommand(
+    id: id,
+    voucherRepository: ref.watch(voucherRepositoryProvider),
     analytics: ref.watch(firebaseAnalyticsProvider),
   );
 });

--- a/lib/presentation/voucher/voucher_buttons.widget.dart
+++ b/lib/presentation/voucher/voucher_buttons.widget.dart
@@ -36,13 +36,21 @@ class VoucherButtons extends ConsumerWidget {
         SizedBox(
           width: double.infinity,
           child: OutlinedButton.icon(
-            onPressed: () => _onImageSavePressed(ref),
+            onPressed: voucher.when(
+              data: (v) => () => v.imageUrl != null
+                  ? _onImageSavePressed(ref)
+                  : showConfirm(
+                      content: const Text('원본 이미지가 등록되지 않았습니다.'),
+                    ),
+              loading: () => null,
+              error: (error, stackTrace) => throw error,
+            ),
             icon: const Icon(
-              Icons.file_download_outlined,
+              Icons.search_outlined,
               color: Colors.grey,
             ),
             label: Text(
-              '이미지 저장',
+              '원본 이미지 보기',
               style: Theme.of(context).textTheme.labelLarge?.copyWith(
                     color: Colors.grey,
                   ),
@@ -130,7 +138,10 @@ class VoucherButtons extends ConsumerWidget {
   }
 
   void _onImageSavePressed(WidgetRef ref) async {
-    showModal(const VoucherRawImageScreen());
+    final presignedUrl = await ref.watch(
+      fetchVoucherImageUrlCommandProvider(voucherId),
+    )();
+    showModal(VoucherRawImageScreen(presignedUrl));
   }
 
   void _onEditPressed() {

--- a/lib/presentation/voucher/voucher_raw_image.screen.dart
+++ b/lib/presentation/voucher/voucher_raw_image.screen.dart
@@ -1,11 +1,16 @@
 // 🐦 Flutter imports:
 import 'package:flutter/widgets.dart';
 
-class VoucherRawImageScreen extends StatelessWidget {
-  const VoucherRawImageScreen({super.key});
+// 📦 Package imports:
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class VoucherRawImageScreen extends ConsumerWidget {
+  final String presignedUrl;
+
+  const VoucherRawImageScreen(this.presignedUrl, {super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Placeholder();
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Image.network(presignedUrl);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -745,7 +745,7 @@ packages:
     source: hosted
     version: "1.9.1"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   url_launcher: ^6.2.1
   image_picker: ^1.0.4
   flutter_speed_dial: ^7.0.0
+  mime: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request updates the voucher repository and API to use presigned URLs for images instead of direct URLs. It also adds a new command to fetch the presigned URL for a voucher image and updates the voucher image upload method to use the mime package. Finally, it refactors the voucher image save button to show the original image if available.