### PR TITLE
Update scroll physics in HomeScreen ListView

### DIFF
--- a/lib/presentation/home/home.screen.dart
+++ b/lib/presentation/home/home.screen.dart
@@ -224,7 +224,9 @@ class HomeScreen extends ConsumerWidget {
         ref.invalidate(voucherIdsProvider);
       },
       child: ListView.separated(
-        physics: const ClampingScrollPhysics(),
+        physics: const AlwaysScrollableScrollPhysics(
+          parent: ClampingScrollPhysics(),
+        ),
         itemCount: listItems.length,
         itemBuilder: (context, index) => listItems[index],
         separatorBuilder: (context, index) {


### PR DESCRIPTION
This pull request updates the scroll physics in the HomeScreen ListView to use AlwaysScrollableScrollPhysics with a parent of ClampingScrollPhysics. This change ensures that the ListView is always scrollable, even when the content is smaller than the viewport. This improves the user experience and makes the app more consistent with other scrollable views.