### PR TITLE
Add ProviderLogger, fix date parsing, and add pull-to-refresh functionality to notifications screen

### DIFF
--- a/lib/data/dto/notification.dto.dart
+++ b/lib/data/dto/notification.dto.dart
@@ -19,9 +19,9 @@ class NotificationDto extends Notification {
           : null,
       type: json['type'],
       message: json['message'],
-      notifiedAt: DateTime.parse(json['notified_at']),
+      notifiedAt: DateTime.parse('${json['notified_at']}Z'),
       checkedAt: (json.containsKey('checked_at') && json['checked_at'] != null)
-          ? DateTime.parse(json['checked_at'])
+          ? DateTime.parse('${json['checked_at']}Z')
           : null,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:gifthub/exception.boundary.dart';
 import 'package:gifthub/firebase_options.dart';
 import 'package:gifthub/presentation/app.dart';
+import 'package:gifthub/presentation/providers/provider.logger.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -57,8 +58,11 @@ Future<void> main() async {
   ]);
 
   runApp(
-    const ProviderScope(
-      child: ExceptionBoundary(
+    ProviderScope(
+      observers: [
+        ProviderLogger(),
+      ],
+      child: const ExceptionBoundary(
         child: App(),
       ),
     ),

--- a/lib/presentation/notifications/notifications.screen.dart
+++ b/lib/presentation/notifications/notifications.screen.dart
@@ -39,12 +39,17 @@ class NotificationsScreen extends ConsumerWidget {
   Widget _buildBody(BuildContext context, WidgetRef ref) {
     final notifications = ref.watch(notificationsProvider);
     notifications.sort((a, b) => b.notifiedAt.compareTo(a.notifiedAt));
-    return ListView.separated(
-      padding: const EdgeInsets.all(padding),
-      itemCount: notifications.length,
-      itemBuilder: (context, index) =>
-          NotificationCard(notifications[index].id),
-      separatorBuilder: (context, index) => const SizedBox(height: padding),
+    return RefreshIndicator(
+      onRefresh: () async {
+        ref.invalidate(notificationsProvider);
+      },
+      child: ListView.separated(
+        padding: const EdgeInsets.all(padding),
+        itemCount: notifications.length,
+        itemBuilder: (context, index) =>
+            NotificationCard(notifications[index].id),
+        separatorBuilder: (context, index) => const SizedBox(height: padding),
+      ),
     );
   }
 }

--- a/lib/presentation/providers/provider.logger.dart
+++ b/lib/presentation/providers/provider.logger.dart
@@ -1,0 +1,44 @@
+// 📦 Package imports:
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
+
+class ProviderLogger extends ProviderObserver {
+  final logger = Logger();
+
+  @override
+  void didAddProvider(
+    ProviderBase<Object?> provider,
+    Object? value,
+    ProviderContainer container,
+  ) {
+    logger.t('Provider $provider was initialized with $value');
+  }
+
+  @override
+  void didDisposeProvider(
+    ProviderBase<Object?> provider,
+    ProviderContainer container,
+  ) {
+    logger.t('Provider $provider was disposed');
+  }
+
+  @override
+  void didUpdateProvider(
+    ProviderBase<Object?> provider,
+    Object? previousValue,
+    Object? newValue,
+    ProviderContainer container,
+  ) {
+    logger.t('Provider $provider was updated from $previousValue to $newValue');
+  }
+
+  @override
+  void providerDidFail(
+    ProviderBase<Object?> provider,
+    Object error,
+    StackTrace stackTrace,
+    ProviderContainer container,
+  ) {
+    logger.e('Provider $provider failed', error: error, stackTrace: stackTrace);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -736,6 +736,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "6bbb9d6f7056729537a4309bda2e74e18e5d9f14302489cc1e93f33b3fe32cac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2+1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   flutter_speed_dial: ^7.0.0
   mime: ^1.0.4
   carousel_slider: ^4.2.1
+  logger: ^2.0.2+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request adds a new provider observer, ProviderLogger, to log provider changes. It also fixes a bug in the date parsing of NotificationDto. Finally, it adds pull-to-refresh functionality to the notifications screen, allowing users to refresh the list of notifications by pulling down on the screen.

No issue number referenced.