### PR TITLE
Fix voucher cancel button functionality

### DIFF
--- a/lib/presentation/voucher/voucher_buttons.widget.dart
+++ b/lib/presentation/voucher/voucher_buttons.widget.dart
@@ -232,8 +232,8 @@ class VoucherButtons extends ConsumerWidget {
           Text('정말 취소하시겠습니까?'),
         ],
       ),
-      onConfirmPressed: () {
-        ref.watch(retrieveVoucherCommandProvider(voucherId))();
+      onConfirmPressed: () async {
+        await ref.watch(retrieveVoucherCommandProvider(voucherId))();
         ref.invalidate(voucherProvider(voucherId));
       },
       confirmText: '네',


### PR DESCRIPTION
This pull request fixes the issue with the voucher cancel button not working properly. The onConfirmPressed function has been updated to use async/await and the voucherProvider is now invalidated after the command is executed.