### PR TITLE
Fix balance formatting in Voucher entity

### DIFF
--- a/lib/domain/entities/voucher.entity.dart
+++ b/lib/domain/entities/voucher.entity.dart
@@ -41,7 +41,7 @@ class Voucher with EquatableMixin {
   bool get isExpired => remainDays < 0;
   bool get aboutToExpire => !isExpired && remainDays < 7;
 
-  String get balanceFormatted => currencyFormat(balance);
+  String get balanceFormatted => currencyFormat(_balance);
   String get expiresAtFormatted {
     final difference = expiresAt.difference(
       DateTime.now().copyWith(


### PR DESCRIPTION
This pull request fixes the balance formatting in the Voucher entity by updating the `balanceFormatted` getter to use the private `_balance` variable instead of the `balance` variable. This ensures that the balance is correctly formatted in the UI.